### PR TITLE
Lookup: Make it possible to find specific entry in a certain group

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ This Ansible lookup plugin allows you to search for entries in a KeePass (kdbx) 
   debug:
     msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', title='My Entry') }}"
 
+- name: Find an entry by title in a specific group
+  debug:
+    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group', title='My Entry', recursive=False) }}"
+
 - name: Find entries in a specific group
   debug:
     msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group', recursive=False) }}"

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -229,7 +229,7 @@ class LookupModule(LookupBase):
                     self._display.vvv(f"Skipping non-entry object: {entry}")
 
         self._display.v("Final search parameters used: {}".format(kwargs))
-        return ret # if type(ret) is list
+        return ret
 
     def match_entry(self, entry, title, username, notes, url, tags, regex):
         """Helper function to match entries against the search criteria."""

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -169,46 +169,52 @@ class LookupModule(LookupBase):
                 raise AnsibleError("Could not open the database, as the checksum of the database is wrong. This could be caused by a corrupt database.") from exc
 
             entries = []
-            if group_path and group_path != "/":
-                # Split the group_path into a list of group names
-                group_path_list = group_path.split('/')
-                self._display.vv("Searching for group path: {}".format(group_path_list))
-                group = kp.find_groups(path=group_path_list, first=True)
-                if not group:
-                    raise AnsibleError(f"Group '{group_path}' not found in the database.")
-                self._display.vv("Group found: {}".format(group))
-                entries = group.entries  # Return all entries in this group
-            else:
-                # Search in root group
-                if not any([title, username, notes, url, tags]):
+            if not any([title, username, notes, url, tags]):
+                if group_path and group_path != "/":
+                    # Split the group_path into a list of group names
+                    group_path_list = group_path.split('/')
+                    self._display.vv("Searching for group path: {}".format(group_path_list))
+                    group = kp.find_groups(path=group_path_list, first=True)
+                    if not group:
+                        raise AnsibleError(f"Group '{group_path}' not found in the database.")
+                    self._display.vv("Group found: {}".format(group))
+                    entries = group.entries  # Return all entries in this group
+                else:
+                    # Search in root group
                     # Alle Einträge in der Wurzelgruppe zurückgeben
                     self._display.vv("Returning all entries in the root group")
                     entries = kp.entries
-                else:
-                    # Filtered search
-                    search_params = {
-                        'recursive': recursive,
-                        'regex': regex,
-                    }
-                    if title:
-                        search_params['title'] = title
-                    if username:
-                        search_params['username'] = username
-                    if notes:
-                        search_params['notes'] = notes
-                    if url:
-                        search_params['url'] = url
-                    if tags and tags != ['']:
-                        search_params['tags'] = tags
+            else:
+                # Filtered search
+                search_params = {
+                    'recursive': recursive,
+                    'regex': regex,
+                }
+                if title:
+                    search_params['title'] = title
+                if username:
+                    search_params['username'] = username
+                if notes:
+                    search_params['notes'] = notes
+                if url:
+                    search_params['url'] = url
+                if tags and tags != ['']:
+                    search_params['tags'] = tags
+                if group_path and group_path != "/":
+                    group = kp.find_groups(name=group_path, first=True)
+                    if not group:
+                        raise AnsibleError(f"Group '{group_path}' not found in the database.")
+                    search_params['group'] = group
+                
 
-                    if not recursive and group_path in [None, "/"]:
-                        # Explicit search in the root group if not recursive
-                        self._display.vv("Performing non-recursive search in the root group")
-                        root_group = kp.root_group
-                        entries = [e for e in root_group.entries if self.match_entry(e, title, username, notes, url, tags, regex)]
-                    else:
-                        self._display.vv("Search parameters: {}".format(search_params))
-                        entries = kp.find_entries(**search_params)
+                if not recursive and group_path in [None, "/"]:
+                    # Explicit search in the root group if not recursive
+                    self._display.vv("Performing non-recursive search in the root group")
+                    root_group = kp.root_group
+                    entries = [e for e in root_group.entries if self.match_entry(e, title, username, notes, url, tags, regex)]
+                else:
+                    self._display.vv("Search parameters: {}".format(search_params))
+                    entries = kp.find_entries(**search_params)
 
             self._display.vv("Number of entries found: {}".format(len(entries)))
 
@@ -223,7 +229,7 @@ class LookupModule(LookupBase):
                     self._display.vvv(f"Skipping non-entry object: {entry}")
 
         self._display.v("Final search parameters used: {}".format(kwargs))
-        return ret
+        return ret # if type(ret) is list
 
     def match_entry(self, entry, title, username, notes, url, tags, regex):
         """Helper function to match entries against the search criteria."""


### PR DESCRIPTION
Hey thanks for your work! This collection really makes my life easier! :pray: 

I noticed that it wasn't really possible to find entries within a group via lookup. I took the liberty to implement it. 
I tried my best to stick to your coding style.

**Current Situation:** If a `group_path` is defined, all other parameters are ignored. This prevents us from finding a specific entry in a given group.

**Suggested Solution:** By slightly adjusting the logic the lookup now takes the `group_path` into account. If only `group_path` is given, all entries in the group are returned. This is the old behavior so theoretically it should not break anything. :crossed_fingers:  

**Attention:** I wasn't sure how your changelog/galaxy config is handled so this PR only includes changes in code logic.

Let me know what you think! :)

BR Jay