### PR TITLE
fix: correct lookup EXAMPLES, README examples, bump version to 1.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ Torie\_Coding.Keepass Release Notes
 
 .. contents:: Topics
 
+v1.4.0
+======
+
+Release Summary
+---------------
+
+Fix and improve lookup plugin EXAMPLES and README.md lookup section. Corrects FQCN usage, fixes a syntax error in examples, removes a duplicate example, and introduces the recommended ``set_fact`` field-access pattern.
+
+Minor Changes
+-------------
+
+- README.md - Remove duplicate example block in lookup section and align examples with best-practice ``set_fact`` + FQCN module names pattern.
+- lookup - Rewrite EXAMPLES block to use ``ansible.builtin.set_fact`` with field-access pattern and ``wantlist=True`` for multi-entry lookups.
+
+Bugfixes
+--------
+
+- lookup - Fix 3 of 4 EXAMPLES using short name ``'lookup'`` instead of FQCN ``'torie_coding.keepass.lookup'``.
+- lookup - Fix ``recursive=False`` placed outside Jinja2 ``{{ }}`` block causing a syntax error.
+
 v1.3.3
 ======
 

--- a/README.md
+++ b/README.md
@@ -182,25 +182,44 @@ This Ansible lookup plugin allows you to search for entries in a KeePass (kdbx) 
 #### Example
 
 ```yaml
-- name: Find an entry by title in KeePass database
-  debug:
-    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', title='My Entry') }}"
+# Retrieve a single entry by title and access its fields directly
+- name: Find an entry by title and store it
+  ansible.builtin.set_fact:
+    kp_entry: "{{ lookup('torie_coding.keepass.lookup', 'entry',
+                  database='/path/to/database.kdbx',
+                  database_password='secret',
+                  title='My Entry') }}"
 
-- name: Find entries in a specific group
-  debug:
-    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group', recursive=False) }}"
+- name: Show the retrieved password
+  ansible.builtin.debug:
+    msg: "Password is {{ kp_entry.password }}"
 
-- name: Find an entry by title in a specific group
-  debug:
-    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group', title='My Entry', recursive=False) }}"
+- name: Write the password to a file
+  ansible.builtin.copy:
+    content: "{{ kp_entry.password }}"
+    dest: /tmp/my_entry_password.txt
 
-- name: Find an entry by title in a specific group
-  debug:
-    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group', title='My Entry', recursive=False) }}"
+# Retrieve multiple entries (use wantlist=True to always get a list)
+- name: Find all entries in a specific group
+  ansible.builtin.set_fact:
+    kp_entries: "{{ lookup('torie_coding.keepass.lookup', 'entry',
+                    database='/path/to/database.kdbx',
+                    database_password='secret',
+                    group_path='My Group',
+                    recursive=False,
+                    wantlist=True) }}"
+
+- name: Show all group entries
+  ansible.builtin.debug:
+    var: kp_entries
 
 - name: Find entries with a specific tag
-  debug:
-    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', tags=['important']) }}"
+  ansible.builtin.set_fact:
+    kp_entries: "{{ lookup('torie_coding.keepass.lookup', 'entry',
+                    database='/path/to/database.kdbx',
+                    database_password='secret',
+                    tags=['important'],
+                    wantlist=True) }}"
 ```
 
 ## Installation

--- a/archive/1.4.0-archive/40-fix-lookup-examples.yaml
+++ b/archive/1.4.0-archive/40-fix-lookup-examples.yaml
@@ -1,0 +1,9 @@
+bugfixes:
+- lookup - Fix 3 of 4 EXAMPLES using short name ``'lookup'`` instead of FQCN ``'torie_coding.keepass.lookup'``.
+- lookup - Fix ``recursive=False`` placed outside Jinja2 ``{{ }}`` block causing a syntax error.
+minor_changes:
+- lookup - Rewrite EXAMPLES block to use ``ansible.builtin.set_fact`` with field-access pattern and ``wantlist=True`` for multi-entry lookups.
+- README.md - Remove duplicate example block in lookup section and align examples with best-practice ``set_fact`` + FQCN module names pattern.
+release_summary: 'Fix and improve lookup plugin EXAMPLES and README.md lookup section.
+  Corrects FQCN usage, fixes a syntax error in examples, removes a duplicate example,
+  and introduces the recommended ``set_fact`` → field-access pattern.'

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -207,3 +207,22 @@ releases:
     fragments:
     - 37-fix-group-search-with-params.yaml
     release_date: '2025-04-08'
+  1.4.0:
+    changes:
+      bugfixes:
+      - lookup - Fix 3 of 4 EXAMPLES using short name ``'lookup'`` instead of FQCN
+        ``'torie_coding.keepass.lookup'``.
+      - lookup - Fix ``recursive=False`` placed outside Jinja2 ``{{ }}`` block causing
+        a syntax error.
+      minor_changes:
+      - README.md - Remove duplicate example block in lookup section and align examples
+        with best-practice ``set_fact`` + FQCN module names pattern.
+      - lookup - Rewrite EXAMPLES block to use ``ansible.builtin.set_fact`` with field-access
+        pattern and ``wantlist=True`` for multi-entry lookups.
+      release_summary: Fix and improve lookup plugin EXAMPLES and README.md lookup
+        section. Corrects FQCN usage, fixes a syntax error in examples, removes a
+        duplicate example, and introduces the recommended ``set_fact`` field-access
+        pattern.
+    fragments:
+    - 40-fix-lookup-examples.yaml
+    release_date: '2026-05-13'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: torie_coding
 name: keepass
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.3
+version: 1.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -95,21 +95,42 @@ options:
 
 
 EXAMPLES = """
-- name: Find an entry by title in KeePass database
-  debug:
-    msg: "{{ lookup('lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', title='My Entry') }}"
+- name: Find an entry by title and store it
+  ansible.builtin.set_fact:
+    kp_entry: "{{ lookup('torie_coding.keepass.lookup', 'entry',
+                  database='/path/to/database.kdbx',
+                  database_password='secret',
+                  title='My Entry') }}"
 
-- name: Find entries in a specific group 
-  debug:
-    msg: "{{ lookup('lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group'), recursive=False }}"
+- name: Show the retrieved password
+  ansible.builtin.debug:
+    msg: "Password is {{ kp_entry.password }}"
 
-- name: Find an entry by title in a specific group
-  debug:
-    msg: "{{ lookup('torie_coding.keepass.lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', group_path='My Group', title='My Entry', recursive=False) }}"
+- name: Write the password to a file
+  ansible.builtin.copy:
+    content: "{{ kp_entry.password }}"
+    dest: /tmp/my_entry_password.txt
+
+- name: Find all entries in a specific group
+  ansible.builtin.set_fact:
+    kp_entries: "{{ lookup('torie_coding.keepass.lookup', 'entry',
+                    database='/path/to/database.kdbx',
+                    database_password='secret',
+                    group_path='My Group',
+                    recursive=False,
+                    wantlist=True) }}"
+
+- name: Show all group entries
+  ansible.builtin.debug:
+    var: kp_entries
 
 - name: Find entries with a specific tag
-  debug:
-    msg: "{{ lookup('lookup', 'entry', database='/path/to/database.kdbx', database_password='secret', tags=['important']) }}"
+  ansible.builtin.set_fact:
+    kp_entries: "{{ lookup('torie_coding.keepass.lookup', 'entry',
+                    database='/path/to/database.kdbx',
+                    database_password='secret',
+                    tags=['important'],
+                    wantlist=True) }}"
 """
 
 RETURN = """


### PR DESCRIPTION
## Summary

Fixes 5 documentation bugs in the lookup plugin and bumps the collection version to **1.4.0**.

---

### Changes

#### `plugins/lookup/lookup.py` — EXAMPLES block

| # | Bug |
|---|-----|
| 1 | 3× short plugin name `'lookup'` → FQCN `'torie_coding.keepass.lookup'` |
| 2 | `recursive=False` placed **outside** the Jinja2 `{{ }}` block (syntax error) |
| 3 | No FQCN module names, no `set_fact` → field-access pattern |

#### `README.md` — lookup example section

| # | Bug |
|---|-----|
| 4 | Duplicate example block (same task listed twice) |
| 5 | Inline `debug:` pattern — no `set_fact`, no FQCN module names |

All examples now use:
- `'torie_coding.keepass.lookup'` (FQCN)
- `ansible.builtin.set_fact` + field-access (e.g. `kp_entry.password`)
- `wantlist=True` for multi-entry lookups
- FQCN module names (`ansible.builtin.debug`, `ansible.builtin.copy`)

#### `galaxy.yml`

- Version bumped `1.3.3` → `1.4.0`

#### Changelog

- `CHANGELOG.rst` and `changelogs/changelog.yml` updated for v1.4.0
- Fragment archived to `archive/1.4.0-archive/`

---

Closes #40